### PR TITLE
chore: update axios to ^1.16.1 (security)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "aftership": "^5.3.0",
     "async": "2.6.4",
-    "axios": ">=0.21.1",
+    "axios": "^1.16.1",
     "camo-url": "^0.1.5",
     "es6-promise": "~3.2.0",
     "hubot": "^3.3.2",


### PR DESCRIPTION
## Summary
- Tightens `axios` from `>=0.21.1` (any version) to `^1.16.1` (current stable)
- Closes 12 Dependabot alerts: 4 HIGH, 7 MEDIUM, 1 LOW

## CVEs fixed
All `axios` vulnerabilities including SSRF (CVE-2025-27152, CVE-2026-42038, CVE-2026-42043), DoS (CVE-2021-3749, CVE-2026-25639), CSRF (CVE-2023-45857, CVE-2026-42042), and header/proxy issues.

## Test plan
- [ ] Run `npm install` to confirm dependencies resolve cleanly against the new constraint
- [ ] Confirm Dependabot alerts close after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)